### PR TITLE
Add Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.10-slim
+
+# Install system dependencies for audio processing
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ffmpeg \
+        espeak-ng \
+        libportaudio2 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the application source
+COPY . .
+
+# Default to showing the CLI help
+ENTRYPOINT ["python", "translator.py"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -24,3 +24,15 @@ python translator.py de --mic --play
 ```
 
 Use `--duration` to specify the recording time in seconds.
+
+## Docker
+You can also run the translator inside a container. Build the image and run the CLI:
+```bash
+docker build -t aitranslator .
+docker run --rm -it aitranslator --help
+```
+
+With Docker Compose:
+```bash
+docker compose run translator --help
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.9'
+services:
+  translator:
+    build: .
+    volumes:
+      - .:/app
+    command: ["--help"]
+    tty: true


### PR DESCRIPTION
## Summary
- add Dockerfile with system and Python dependencies
- create a simple docker-compose.yml to run the app
- update README with Docker instructions

## Testing
- `python translator.py --help` *(fails: PortAudio library not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b439ed8a883288ee24093711b2f3b