### PR TITLE
Add web frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ python translator.py de --mic --play
 
 Use `--duration` to specify the recording time in seconds.
 
+## Web interface
+You can launch a small web application with:
+
+```bash
+python webapp.py
+```
+
+Open <http://localhost:5000> in your browser to upload an audio file. The page
+will show the translated text and an audio player with the generated speech.
+
 ## Docker
 You can also run the translator inside a container. Build the image and run the CLI:
 ```bash
@@ -35,4 +45,9 @@ docker run --rm -it aitranslator --help
 With Docker Compose:
 ```bash
 docker compose run translator --help
+```
+
+To test the web interface with Docker Compose:
+```bash
+docker compose up web
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,11 @@ services:
       - .:/app
     command: ["--help"]
     tty: true
+  web:
+    build: .
+    image: translator:latest
+    volumes:
+      - .:/app
+    ports:
+      - "5000:5000"
+    command: ["python", "webapp.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ openai-whisper
 kokoro>=0.9.4
 soundfile
 sounddevice
+Flask
+numpy

--- a/translator.py
+++ b/translator.py
@@ -6,6 +6,8 @@ import soundfile as sf
 import sounddevice as sd
 import tempfile
 from typing import Optional
+import io
+import numpy as np
 
 
 def record_from_microphone(duration: int = 5, sample_rate: int = 16000) -> str:
@@ -43,6 +45,26 @@ def text_to_speech(
             sd.wait()
         else:
             sf.write(f"output_{i}.wav", audio, 24000)
+
+
+def text_to_speech_bytes(
+    text: str,
+    lang_code: str = "a",
+    voice: str = "af_heart",
+) -> bytes:
+    """Return generated speech as WAV bytes."""
+    pipeline = KPipeline(lang_code=lang_code)
+    generator = pipeline(text, voice=voice)
+    audio_segments = []
+    for _, _, audio in generator:
+        audio_segments.append(audio)
+    if not audio_segments:
+        return b""
+    combined = np.concatenate(audio_segments)
+    buffer = io.BytesIO()
+    sf.write(buffer, combined, 24000, format="wav")
+    buffer.seek(0)
+    return buffer.read()
 
 
 def main() -> None:

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,55 @@
+import base64
+import tempfile
+import os
+from flask import Flask, request
+from translator import transcribe, translate_text, text_to_speech_bytes
+
+app = Flask(__name__)
+
+INDEX_HTML = """
+<!doctype html>
+<title>AITranslator</title>
+<h1>Speech to Speech Translation</h1>
+<form action="/translate" method="post" enctype="multipart/form-data">
+  <p><input type="file" name="audio" accept="audio/*" required></p>
+  <p>Target language code: <input name="target" value="de"></p>
+  <p>Whisper model: <input name="whisper_model" value="base"></p>
+  <p>EasyNMT model: <input name="easynmt_model" value="opus-mt"></p>
+  <p>TTS lang code: <input name="tts_lang" value="a"></p>
+  <p>Voice: <input name="voice" value="af_heart"></p>
+  <p><button type="submit">Translate</button></p>
+</form>
+"""
+
+@app.route("/")
+def index():
+    return INDEX_HTML
+
+@app.route("/translate", methods=["POST"])
+def translate_route():
+    f = request.files.get("audio")
+    if not f:
+        return "Missing audio", 400
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as tmp:
+        f.save(tmp.name)
+        audio_path = tmp.name
+    whisper_model = request.form.get("whisper_model", "base")
+    easynmt_model = request.form.get("easynmt_model", "opus-mt")
+    tts_lang = request.form.get("tts_lang", "a")
+    voice = request.form.get("voice", "af_heart")
+    target = request.form.get("target", "de")
+
+    text = transcribe(audio_path, whisper_model)
+    translated = translate_text(text, target, easynmt_model)
+    audio_bytes = text_to_speech_bytes(translated, tts_lang, voice)
+    os.remove(audio_path)
+
+    b64 = base64.b64encode(audio_bytes).decode("utf-8")
+    return (
+        f"<h1>Result</h1><p>{translated}</p>"
+        f"<audio controls src='data:audio/wav;base64,{b64}'></audio>"
+        "<p><a href='/'>Back</a></p>"
+    )
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add a Flask-based webapp
- provide `text_to_speech_bytes` helper
- document how to run the web interface
- expose a docker-compose service for the web app
- update dependencies

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile translator.py webapp.py`


------
https://chatgpt.com/codex/tasks/task_e_688b757ecac88328afa3bd7c22734f60