### PR TITLE
Add EasyNMT REST API option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ python translator.py de --mic --play
 
 Use `--duration` to specify the recording time in seconds.
 
+### EasyNMT REST API
+By default the translator sends translation requests to the EasyNMT REST service
+defined in `docker-compose.yml`.  Pass `--use-local-easynmt` if you want to use
+a locally installed EasyNMT library instead.  The REST endpoint can be changed
+via `--rest-url` (or the `EASYNMT_REST_URL` environment variable for the web
+app).
+
 ## Web interface
 You can launch a small web application with:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ soundfile
 sounddevice
 Flask
 numpy
+requests

--- a/webapp.py
+++ b/webapp.py
@@ -4,6 +4,9 @@ import os
 from flask import Flask, request
 from translator import transcribe, translate_text, text_to_speech_bytes
 
+REST_URL = os.getenv("EASYNMT_REST_URL", "http://easynmt-api/translate")
+USE_LOCAL = os.getenv("USE_LOCAL_EASYNMT", "false").lower() in ("1", "true", "yes")
+
 app = Flask(__name__)
 
 INDEX_HTML = """
@@ -39,8 +42,9 @@ def translate_route():
     voice = request.form.get("voice", "af_heart")
     target = request.form.get("target", "de")
 
+    rest_url = None if USE_LOCAL else REST_URL
     text = transcribe(audio_path, whisper_model)
-    translated = translate_text(text, target, easynmt_model)
+    translated = translate_text(text, target, easynmt_model, rest_url=rest_url)
     audio_bytes = text_to_speech_bytes(translated, tts_lang, voice)
     os.remove(audio_path)
 


### PR DESCRIPTION
## Summary
- support calling EasyNMT via HTTP
- allow using REST API in CLI and webapp
- document REST mode
- include `requests` dependency

## Testing
- `python -m py_compile translator.py webapp.py`

------
https://chatgpt.com/codex/tasks/task_e_688ca569c8b4832896db9f0813750c5d