### PR TITLE
Add microphone recording to web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ You can launch a small web application with:
 python webapp.py
 ```
 
-Open <http://localhost:5000> in your browser to upload an audio file. The page
+Open <http://localhost:5000> in your browser to upload an audio file or record
+directly from the microphone using the **Start Recording** button. The page
 will show the translated text and an audio player with the generated speech.
 
 ## Docker

--- a/webapp.py
+++ b/webapp.py
@@ -1,6 +1,7 @@
 import base64
 import tempfile
 import os
+import subprocess
 from flask import Flask, request
 from translator import transcribe, translate_text, text_to_speech_bytes
 
@@ -9,12 +10,35 @@ USE_LOCAL = os.getenv("USE_LOCAL_EASYNMT", "false").lower() in ("1", "true", "ye
 
 app = Flask(__name__)
 
+
+def convert_to_wav(input_path: str) -> str:
+    """Convert an audio file to WAV format using ffmpeg."""
+    if input_path.lower().endswith(".wav"):
+        return input_path
+    out_fd = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
+    out_path = out_fd.name
+    out_fd.close()
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        input_path,
+        "-ac",
+        "1",
+        "-ar",
+        "16000",
+        out_path,
+    ]
+    subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    os.remove(input_path)
+    return out_path
+
 INDEX_HTML = """
 <!doctype html>
 <title>AITranslator</title>
 <h1>Speech to Speech Translation</h1>
-<form action="/translate" method="post" enctype="multipart/form-data">
-  <p><input type="file" name="audio" accept="audio/*" required></p>
+<form id="uploadForm" action="/translate" method="post" enctype="multipart/form-data">
+  <p><input id="audioInput" type="file" name="audio" accept="audio/*" required></p>
   <p>Target language code: <input name="target" value="de"></p>
   <p>Whisper model: <input name="whisper_model" value="base"></p>
   <p>EasyNMT model: <input name="easynmt_model" value="opus-mt"></p>
@@ -22,6 +46,53 @@ INDEX_HTML = """
   <p>Voice: <input name="voice" value="af_heart"></p>
   <p><button type="submit">Translate</button></p>
 </form>
+
+<h2>Microphone</h2>
+<p>
+  <button type="button" id="startRecord">Start Recording</button>
+  <button type="button" id="stopRecord" disabled>Stop</button>
+</p>
+<p><audio id="recordedAudio" controls style="display:none"></audio></p>
+
+<script>
+let mediaRecorder;
+let chunks = [];
+const startBtn = document.getElementById('startRecord');
+const stopBtn = document.getElementById('stopRecord');
+const audioElem = document.getElementById('recordedAudio');
+const fileInput = document.getElementById('audioInput');
+
+startBtn.onclick = async () => {
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    chunks = [];
+    mediaRecorder = new MediaRecorder(stream);
+    mediaRecorder.ondataavailable = e => chunks.push(e.data);
+    mediaRecorder.onstop = () => {
+      const blob = new Blob(chunks, {type: 'audio/webm'});
+      const file = new File([blob], 'recording.webm', {type: 'audio/webm'});
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      fileInput.files = dt.files;
+      audioElem.src = URL.createObjectURL(blob);
+      audioElem.style.display = 'block';
+    };
+    mediaRecorder.start();
+    startBtn.disabled = true;
+    stopBtn.disabled = false;
+  } catch(err) {
+    alert('Could not start recording: ' + err);
+  }
+};
+
+stopBtn.onclick = () => {
+  if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+    mediaRecorder.stop();
+  }
+  startBtn.disabled = false;
+  stopBtn.disabled = true;
+};
+</script>
 """
 
 @app.route("/")
@@ -33,9 +104,11 @@ def translate_route():
     f = request.files.get("audio")
     if not f:
         return "Missing audio", 400
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as tmp:
+    ext = os.path.splitext(f.filename)[1]
+    with tempfile.NamedTemporaryFile(delete=False, suffix=ext or ".dat") as tmp:
         f.save(tmp.name)
         audio_path = tmp.name
+    audio_path = convert_to_wav(audio_path)
     whisper_model = request.form.get("whisper_model", "base")
     easynmt_model = request.form.get("easynmt_model", "opus-mt")
     tts_lang = request.form.get("tts_lang", "a")


### PR DESCRIPTION
## Summary
- add `convert_to_wav` helper in `webapp.py` to convert uploaded audio to WAV
- embed HTML/JS microphone recorder so users can record in the browser
- mention microphone recording in README

## Testing
- `python -m py_compile webapp.py translator.py`

------
https://chatgpt.com/codex/tasks/task_e_688ca85daac483289f83b19b9d32d835