### PR TITLE
Refactor HTML into templates and static files

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,37 @@
+let mediaRecorder;
+let chunks = [];
+const startBtn = document.getElementById('startRecord');
+const stopBtn = document.getElementById('stopRecord');
+const audioElem = document.getElementById('recordedAudio');
+const fileInput = document.getElementById('audioInput');
+
+startBtn.onclick = async () => {
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    chunks = [];
+    mediaRecorder = new MediaRecorder(stream);
+    mediaRecorder.ondataavailable = e => chunks.push(e.data);
+    mediaRecorder.onstop = () => {
+      const blob = new Blob(chunks, {type: 'audio/webm'});
+      const file = new File([blob], 'recording.webm', {type: 'audio/webm'});
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      fileInput.files = dt.files;
+      audioElem.src = URL.createObjectURL(blob);
+      audioElem.style.display = 'block';
+    };
+    mediaRecorder.start();
+    startBtn.disabled = true;
+    stopBtn.disabled = false;
+  } catch(err) {
+    alert('Could not start recording: ' + err);
+  }
+};
+
+stopBtn.onclick = () => {
+  if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+    mediaRecorder.stop();
+  }
+  startBtn.disabled = false;
+  stopBtn.disabled = true;
+};

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,10 @@
+body {
+    font-family: sans-serif;
+    max-width: 600px;
+    margin: auto;
+    padding: 1em;
+}
+
+#recordedAudio {
+    display: none;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+<head>
+    <title>AITranslator</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+<h1>Speech to Speech Translation</h1>
+<form id="uploadForm" action="/translate" method="post" enctype="multipart/form-data">
+  <p><input id="audioInput" type="file" name="audio" accept="audio/*" required></p>
+  <p>Target language code: <input name="target" value="de"></p>
+  <p>Whisper model: <input name="whisper_model" value="base"></p>
+  <p>EasyNMT model: <input name="easynmt_model" value="opus-mt"></p>
+  <p>TTS lang code: <input name="tts_lang" value="a"></p>
+  <p>Voice: <input name="voice" value="af_heart"></p>
+  <p><button type="submit">Translate</button></p>
+</form>
+
+<h2>Microphone</h2>
+<p>
+  <button type="button" id="startRecord">Start Recording</button>
+  <button type="button" id="stopRecord" disabled>Stop</button>
+</p>
+<p><audio id="recordedAudio" controls></audio></p>
+
+<script src="{{ url_for('static', filename='app.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- move HTML from `webapp.py` into `templates/index.html`
- add `static/style.css` for basic styling
- move JavaScript into `static/app.js`
- update `webapp.py` to render the template

## Testing
- `python -m py_compile webapp.py translator.py`

------
https://chatgpt.com/codex/tasks/task_e_688cabce2af48328a5dbf994fb914189