### PR TITLE
Add dropdown for supported target languages

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,13 @@
 <h1>Speech to Speech Translation</h1>
 <form id="uploadForm" action="/translate" method="post" enctype="multipart/form-data">
   <p><input id="audioInput" type="file" name="audio" accept="audio/*" required></p>
-  <p>Target language code: <input name="target" value="de"></p>
+  <p>Target language code:
+    <select name="target">
+      {% for code in languages %}
+      <option value="{{ code }}" {% if code == 'de' %}selected{% endif %}>{{ code }}</option>
+      {% endfor %}
+    </select>
+  </p>
   <p>Whisper model: <input name="whisper_model" value="base"></p>
   <p>EasyNMT model: <input name="easynmt_model" value="opus-mt"></p>
   <p>TTS lang code: <input name="tts_lang" value="a"></p>


### PR DESCRIPTION
## Summary
- Replace text input for target language with a dropdown populated from supported language codes.
- Parse `notes/easynmt.md` to load EasyNMT's supported languages at runtime.

## Testing
- `python -m py_compile webapp.py`
- `python -c "import importlib, webapp, itertools; importlib.reload(webapp); print(list(itertools.islice(webapp.SUPPORTED_LANGUAGES,10)))"`

------
https://chatgpt.com/codex/tasks/task_e_68a062bb57c48328ae8f6b55144fb611