### PR TITLE
feat: merge record control into single button

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,37 +1,32 @@
 let mediaRecorder;
 let chunks = [];
-const startBtn = document.getElementById('startRecord');
-const stopBtn = document.getElementById('stopRecord');
+const recordBtn = document.getElementById('recordButton');
 const audioElem = document.getElementById('recordedAudio');
 const fileInput = document.getElementById('audioInput');
 
-startBtn.onclick = async () => {
-  try {
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
-    chunks = [];
-    mediaRecorder = new MediaRecorder(stream);
-    mediaRecorder.ondataavailable = e => chunks.push(e.data);
-    mediaRecorder.onstop = () => {
-      const blob = new Blob(chunks, {type: 'audio/webm'});
-      const file = new File([blob], 'recording.webm', {type: 'audio/webm'});
-      const dt = new DataTransfer();
-      dt.items.add(file);
-      fileInput.files = dt.files;
-      audioElem.src = URL.createObjectURL(blob);
-      audioElem.style.display = 'block';
-    };
-    mediaRecorder.start();
-    startBtn.disabled = true;
-    stopBtn.disabled = false;
-  } catch(err) {
-    alert('Could not start recording: ' + err);
-  }
-};
-
-stopBtn.onclick = () => {
-  if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+recordBtn.onclick = async () => {
+  if (!mediaRecorder || mediaRecorder.state === 'inactive') {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+      chunks = [];
+      mediaRecorder = new MediaRecorder(stream);
+      mediaRecorder.ondataavailable = e => chunks.push(e.data);
+      mediaRecorder.onstop = () => {
+        const blob = new Blob(chunks, {type: 'audio/webm'});
+        const file = new File([blob], 'recording.webm', {type: 'audio/webm'});
+        const dt = new DataTransfer();
+        dt.items.add(file);
+        fileInput.files = dt.files;
+        audioElem.src = URL.createObjectURL(blob);
+        audioElem.style.display = 'block';
+        recordBtn.textContent = 'Start Recording';
+      };
+      mediaRecorder.start();
+      recordBtn.textContent = 'Stop Recording';
+    } catch(err) {
+      alert('Could not start recording: ' + err);
+    }
+  } else if (mediaRecorder.state === 'recording') {
     mediaRecorder.stop();
   }
-  startBtn.disabled = false;
-  stopBtn.disabled = true;
 };

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,8 +25,7 @@
 
 <h2>Microphone</h2>
 <p>
-  <button type="button" id="startRecord">Start Recording</button>
-  <button type="button" id="stopRecord" disabled>Stop</button>
+  <button type="button" id="recordButton">Start Recording</button>
 </p>
 <p><audio id="recordedAudio" controls></audio></p>
 


### PR DESCRIPTION
## Summary
- Replace separate start/stop record buttons with single toggle
- Update JS logic to switch between starting and stopping based on recorder state

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a06cc708588328a612bdec0bb7a12a