### PR TITLE
Auto-redirect to main page after translation playback

### DIFF
--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head>
+    <title>Translation Result</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}" type="image/x-icon">
+</head>
+<body>
+<h1>Result</h1>
+<p>{{ translated }}</p>
+<audio id="resultAudio" controls autoplay src="data:audio/wav;base64,{{ audio_b64 }}"></audio>
+<p><a href="/">Back</a></p>
+<script>
+  document.getElementById('resultAudio').addEventListener('ended', function() {
+    window.location.href = '/';
+  });
+</script>
+</body>
+</html>

--- a/webapp.py
+++ b/webapp.py
@@ -84,11 +84,7 @@ def translate_route():
     os.remove(audio_path)
 
     b64 = base64.b64encode(audio_bytes).decode("utf-8")
-    return (
-        f"<h1>Result</h1><p>{translated}</p>"
-        f"<audio controls src='data:audio/wav;base64,{b64}'></audio>"
-        "<p><a href='/'>Back</a></p>"
-    )
+    return render_template("result.html", translated=translated, audio_b64=b64)
 
 if __name__ == "__main__":
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- Render a dedicated result page that autoplays the translated audio and returns to the main page when playback finishes
- Update translation route to use new result template

## Testing
- `python -m py_compile webapp.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1bb2657e083289230e13cc546a760