### PR TITLE
Add quick-access buttons for recent languages

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3,6 +3,44 @@ let chunks = [];
 const recordBtn = document.getElementById('recordButton');
 const audioElem = document.getElementById('recordedAudio');
 const fileInput = document.getElementById('audioInput');
+const formElem = document.getElementById('uploadForm');
+const targetSelect = document.querySelector('select[name="target"]');
+const recentContainerParent = document.getElementById('recent-languages-container');
+const recentContainer = document.getElementById('recent-languages');
+const RECENT_KEY = 'recentLanguages';
+const MAX_RECENT = 5;
+
+function renderRecent() {
+  const recent = JSON.parse(localStorage.getItem(RECENT_KEY) || '[]');
+  if (recent.length === 0) {
+    recentContainerParent.style.display = 'none';
+    return;
+  }
+  recentContainerParent.style.display = 'block';
+  recentContainer.innerHTML = '';
+  recent.forEach(code => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = code;
+    btn.addEventListener('click', () => {
+      targetSelect.value = code;
+    });
+    recentContainer.appendChild(btn);
+  });
+}
+
+renderRecent();
+
+formElem.addEventListener('submit', () => {
+  const selected = targetSelect.value;
+  let recent = JSON.parse(localStorage.getItem(RECENT_KEY) || '[]');
+  recent = recent.filter(c => c !== selected);
+  recent.unshift(selected);
+  if (recent.length > MAX_RECENT) {
+    recent = recent.slice(0, MAX_RECENT);
+  }
+  localStorage.setItem(RECENT_KEY, JSON.stringify(recent));
+});
 
 recordBtn.onclick = async () => {
   if (!mediaRecorder || mediaRecorder.state === 'inactive') {

--- a/static/style.css
+++ b/static/style.css
@@ -8,3 +8,11 @@ body {
 #recordedAudio {
     display: none;
 }
+
+#recent-languages-container {
+    margin-top: 0.5em;
+}
+
+#recent-languages button {
+    margin-right: 0.5em;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,6 +16,7 @@
       {% endfor %}
     </select>
   </p>
+  <p id="recent-languages-container">Recent languages: <span id="recent-languages"></span></p>
   <p>Whisper model: <input name="whisper_model" value="base"></p>
   <p>EasyNMT model: <input name="easynmt_model" value="opus-mt"></p>
   <p>TTS lang code: <input name="tts_lang" value="a"></p>


### PR DESCRIPTION
## Summary
- show recent language choices beneath the target language dropdown
- persist selected languages in browser localStorage and render as buttons for fast selection
- style the recent language buttons with spacing

## Testing
- `python -m py_compile webapp.py`
- `python -m py_compile translator.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1bb98424c83288432e8fd3141bfd0