### PR TITLE
Auto-select TTS language in web UI

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -19,7 +19,6 @@
   <p id="recent-languages-container">Recent languages: <span id="recent-languages"></span></p>
   <p>Whisper model: <input name="whisper_model" value="base"></p>
   <p>EasyNMT model: <input name="easynmt_model" value="opus-mt"></p>
-  <p>TTS lang code: <input name="tts_lang" value="a"></p>
   <p>Voice: <input name="voice" value="af_heart"></p>
   <p><button type="submit">Translate</button></p>
 </form>

--- a/webapp.py
+++ b/webapp.py
@@ -35,6 +35,20 @@ def _load_supported_languages() -> List[str]:
 SUPPORTED_LANGUAGES = _load_supported_languages()
 
 
+# Mapping from translation target language codes to Kokoro TTS language codes.
+# Defaults to American English ("a") when a language is not found.
+TTS_LANG_MAP = {
+    "en": "a",  # American English
+    "es": "e",  # Spanish
+    "fr": "f",  # French
+    "hi": "h",  # Hindi
+    "it": "i",  # Italian
+    "ja": "j",  # Japanese
+    "pt": "p",  # Brazilian Portuguese
+    "zh": "z",  # Mandarin Chinese
+}
+
+
 def convert_to_wav(input_path: str) -> str:
     """Convert an audio file to WAV format using ffmpeg."""
     if input_path.lower().endswith(".wav"):
@@ -76,9 +90,9 @@ def translate_route():
     audio_path = convert_to_wav(audio_path)
     whisper_model = request.form.get("whisper_model", "base")
     easynmt_model = request.form.get("easynmt_model", "opus-mt")
-    tts_lang = request.form.get("tts_lang", "a")
+    target = request.form.get("target", "de").lower()
+    tts_lang = TTS_LANG_MAP.get(target, "a")
     voice = request.form.get("voice", "af_heart")
-    target = request.form.get("target", "de")
 
     rest_url = None if USE_LOCAL else REST_URL
     text = transcribe(audio_path, whisper_model)


### PR DESCRIPTION
## Summary
- map translation language codes to Kokoro TTS codes and default to American English when unsupported
- pick TTS language automatically based on translation target in web interface
- remove manual TTS language input field from UI

## Testing
- `python -m py_compile webapp.py translator.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1c2b9f00c8328aef2681efb7a03e2